### PR TITLE
Remove requirement for callback in delete() as mongoose returns a promise natively.

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,10 +121,6 @@ module.exports = function (schema, options) {
         var callback = typeof first === 'function' ? first : second,
             deletedBy = second !== undefined ? first : null;
 
-        if (typeof callback !== 'function') {
-            throw 'Wrong arguments!';
-        }
-
         this.deleted = true;
 
         if (schema.path('deletedAt')) {
@@ -135,13 +131,13 @@ module.exports = function (schema, options) {
             this.deletedBy = deletedBy;
         }
 
-        this.save(callback);
+        return this.save(callback);
     };
 
     schema.methods.restore = function (callback) {
         this.deleted = false;
         this.deletedAt = undefined;
         this.deletedBy = undefined;
-        this.save(callback);
+        return this.save(callback);
     };
 };

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "devDependencies": {
     "chai": "^3.3.0",
     "istanbul": "^0.4.2",
-    "mocha": "^2.3.3"
+    "mocha": "^2.3.3",
+    "mockgoose": "^5.3.2"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -2,7 +2,10 @@ var should = require('chai').should(),
     expect = require('chai').expect,
     assert = require('assert'),
     mongoose = require('mongoose'),
+    mockgoose = require('mockgoose'),
     Schema = mongoose.Schema;
+
+mockgoose(mongoose);
 
 var mongoose_delete = require('../');
 
@@ -24,11 +27,11 @@ describe("mongoose_delete delete method without callback function", function () 
         mongoose.connection.db.dropCollection("mongoose_delete_test0", function () { done(); });
     });
 
-    it("delete() -> should throw 'Wrong arguments!' message", function (done) {
+    it("delete() -> should return a thenable (Promise)", function (done) {
         Test0.findOne({ name: 'Puffy' }, function (err, puffy) {
             should.not.exist(err);
 
-            expect(puffy.delete).to.throw('Wrong arguments!');
+            expect(puffy.delete()).to.have.property('then');
             done();
         });
     });


### PR DESCRIPTION
Mongoose returns a promise on save if no callback is given, in keeping with this style I would suggest doing the same. If a callback is given, mongoose will call it instead.

Also added mockgoose so mongo isn't required to be set up locally for tests.