### PR TITLE
Methods override fix for existent DB

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ module.exports = function (schema, options) {
         finalList.forEach(function(method) {
             if (method === 'count' || method === 'find' || method === 'findOne') {
                 schema.statics[method] = function () {
-                    return Model[method].apply(this, arguments).where('deleted').equals(false);
+                    return Model[method].apply(this, arguments).where('deleted').ne(true);
                 };
                 schema.statics[method + 'Deleted'] = function () {
                     return Model[method].apply(this, arguments).where('deleted').ne(false);


### PR DESCRIPTION
i tried to implement this to a existent db, tough none of my records had the "deleted" field, so when i override my methods all my rows are ignored since none of them "delete == false"
this will only validate delete == true, so all other rows without this property remain valid.