### PR TITLE
deletedBy as String instead of ObjectId

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ module.exports = function (schema, options) {
     }
 
     if (options.deletedBy === true) {
-        schema.add({ deletedBy: { type: Schema.Types.ObjectId, index: indexFields.deletedBy }});
+        schema.add({ deletedBy: { type: String, index: indexFields.deletedBy }});
     }
 
     schema.pre('save', function (next) {

--- a/test/index.js
+++ b/test/index.js
@@ -154,7 +154,7 @@ describe("mongoose_delete with options: { deletedBy : true }", function () {
             puffy.delete(id, function (err, success) {
                 should.not.exist(err);
 
-                success.deletedBy.should.equal(id);
+                success.deletedBy.should.equal(id.toString());
                 done();
             });
         });


### PR DESCRIPTION
This addresses issue #23 by changing the type of `deletedBy` to `String`, rather than `ObjectId`.

As an alternative, see #25 which allows for setting a custom type. Let me know whichever is better. I can also update the README for the one you choose.

Note that this is a breaking change, and I had to update one of the tests.