### PR TITLE
set custom type for deletedBy

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ module.exports = function (schema, options) {
     }
 
     if (options.deletedBy === true) {
-        schema.add({ deletedBy: { type: Schema.Types.ObjectId, index: indexFields.deletedBy }});
+        schema.add({ deletedBy: { type: options.deletedByType || Schema.Types.ObjectId, index: indexFields.deletedBy }});
     }
 
     schema.pre('save', function (next) {


### PR DESCRIPTION
This addresses issue #23 by adding an option `deleteByType` where the user can set the type of object that will be stored in `deleteBy`. If the option is unset, it will default to `ObjectId`, and this is fully backwards compatible.

An alternative is #24 which sets the type to `String`, but is not backwards compatible.

I can update the README if you want, as well.