### PR TITLE
Counter mongo index bug with $ne and count()

### DIFF
--- a/index.js
+++ b/index.js
@@ -123,10 +123,10 @@ module.exports = function (schema, options) {
         finalList.forEach(function(method) {
             if (method === 'count' || method === 'find' || method === 'findOne') {
                 schema.statics[method] = function () {
-                    return Model[method].apply(this, arguments).where('deleted').ne(true);
+                    return Model[method].apply(this, arguments).where({deleted: false});
                 };
                 schema.statics[method + 'Deleted'] = function () {
-                    return Model[method].apply(this, arguments).where('deleted').ne(false);
+                    return Model[method].apply(this, arguments).where({deleted: true});
                 };
                 schema.statics[method + 'WithDeleted'] = function () {
                     return Model[method].apply(this, arguments);
@@ -135,7 +135,7 @@ module.exports = function (schema, options) {
                 schema.statics[method] = function () {
                     var args = parseUpdateArguments.apply(undefined, arguments);
 
-                    args[0].deleted = {'$ne': true};
+                    args[0].deleted = false;
 
                     return Model[method].apply(this, args);
                 };
@@ -143,7 +143,7 @@ module.exports = function (schema, options) {
                 schema.statics[method + 'Deleted'] = function () {
                     var args = parseUpdateArguments.apply(undefined, arguments);
 
-                    args[0].deleted = {'$ne': false};
+                    args[0].deleted = true;
 
                     return Model[method].apply(this, args);
                 };

--- a/index.js
+++ b/index.js
@@ -121,16 +121,26 @@ module.exports = function (schema, options) {
         }
 
         finalList.forEach(function(method) {
-            if (method === 'count' || method === 'find' || method === 'findOne') {
-                schema.statics[method] = function () {
-                    return Model[method].apply(this, arguments).where({deleted: false});
-                };
-                schema.statics[method + 'Deleted'] = function () {
-                    return Model[method].apply(this, arguments).where({deleted: true});
-                };
-                schema.statics[method + 'WithDeleted'] = function () {
-                    return Model[method].apply(this, arguments);
-                };
+            if (method === 'find' || method === 'findOne') {
+              schema.statics[method] = function () {
+                return Model[method].apply(this, arguments).where('deleted').ne(true);
+              };
+              schema.statics[method + 'Deleted'] = function () {
+                return Model[method].apply(this, arguments).where('deleted').ne(false);
+              };
+              schema.statics[method + 'WithDeleted'] = function () {
+                return Model[method].apply(this, arguments);
+              };
+            } else if (method === 'count') {
+              schema.statics[method] = function () {
+                return Model[method].apply(this, arguments).where({deleted: false});
+              };
+              schema.statics[method + 'Deleted'] = function () {
+                return Model[method].apply(this, arguments).where({deleted: true});
+              };
+              schema.statics[method + 'WithDeleted'] = function () {
+                return Model[method].apply(this, arguments);
+              };
             } else {
                 schema.statics[method] = function () {
                     var args = parseUpdateArguments.apply(undefined, arguments);

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "devDependencies": {
     "chai": "^3.3.0",
     "istanbul": "^0.4.2",
-    "mocha": "^2.3.3"
+    "mocha": "^2.3.3",
+    "mongoose": "4.11.3"
   }
 }


### PR DESCRIPTION
Mongo count run pretty slow when the query includes $ne.

Allow the queries to run in reasonable time when there are millions of data entries. All data must include the deleted field for the count to be reliable