### PR TITLE
Add support for custom field names and custom schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,23 @@ PetSchema.plugin(mongoose_delete, { indexFields: ['deletedAt'] });
 
 ```
 
+### Custom field names or schema type definition
+
+```javascript
+var mongoose_delete = require('mongoose-delete');
+
+var PetSchema = new Schema({
+	name: String
+});
+
+// Add a custom name for each property, will create alias for the original name
+PetSchema.plugin(mongoose_delete, { deletedBy: 'deleted_by', deletedAt: 'deleted_at' });
+
+// Use custom schema type definition by supplying an object
+PetSchema.plugin(mongoose_delete, { deletedBy: { name: 'deleted_by', default: 'None', type: String }, deletedAt: { alias: 'deletedTimestamp' } });
+```
+Expects a Mongoose [Schema Types](https://mongoosejs.com/docs/schematypes.html#schematype-options) object with the added option of `name`.
+
 ## License
 
 The MIT License


### PR DESCRIPTION
We are migrating to mongoose but our `deletedBy/At` fields have different names and for legacy reasons, we can not change this right now. We also need the ability to use a custom getter to transform our value.

#### This PR will added support for
* custom names for both `deletedBy` and `deletedAt`
* ability to supply custom schema type definition for `deletedBy` and `deletedAt` (could make the current `deletedByType` obsolete, can be replaced by `{ deletedBy: { type: String } }`)?

I was inspired by how mongoose handles the `timestamp` schema option. Let me know if you prefer another way. Will resolve issue #92