### PR TITLE
set deleted to false instead of unsetting when calling restore()

### DIFF
--- a/index.js
+++ b/index.js
@@ -309,8 +309,10 @@ module.exports = function (schema, options) {
         }
 
         var doc = {
+            $set:{
+                deleted: false
+            },
             $unset:{
-                deleted: true,
                 deletedAt: true,
                 deletedBy: true
             }


### PR DESCRIPTION
Fix Automattic/mongoose#14338

It looks like this commit: https://github.com/dsanel/mongoose-delete/commit/b8c3cea2321dcd583c78c254d1490b3f72c0c14f made it so that the `restore()` static would unset `deleted` versus setting it to `false`, which is backwards breaking for projects that use `use$neOperator: false`.